### PR TITLE
Reset mockExpectations at Set method so that FormatFunc is called

### DIFF
--- a/cmd/minimock/minimock.go
+++ b/cmd/minimock/minimock.go
@@ -330,6 +330,7 @@ const template = `
 		//Set uses given function f as a mock of {{$interfaceName}}.{{$methodName}} method
 		func (m *m{{$structName}}{{$methodName}}) Set(f func({{params $method}}) ({{results $method}})) *{{$structName}}{
 			m.mock.{{$methodName}}Func = f
+			m.mockExpectations = nil
 			return m.mock
 		}
 

--- a/tests/formatter_mock.go
+++ b/tests/formatter_mock.go
@@ -64,6 +64,7 @@ func (m *mFormatterMockFormat) Return(r string) *FormatterMock {
 //Set uses given function f as a mock of Formatter.Format method
 func (m *mFormatterMockFormat) Set(f func(p string, p1 ...interface{}) (r string)) *FormatterMock {
 	m.mock.FormatFunc = f
+	m.mockExpectations = nil
 	return m.mock
 }
 

--- a/tests/tester_mock_test.go
+++ b/tests/tester_mock_test.go
@@ -81,6 +81,7 @@ func (m *mTesterMockError) Return() *TesterMock {
 //Set uses given function f as a mock of Tester.Error method
 func (m *mTesterMockError) Set(f func(p ...interface{})) *TesterMock {
 	m.mock.ErrorFunc = f
+	m.mockExpectations = nil
 	return m.mock
 }
 
@@ -147,6 +148,7 @@ func (m *mTesterMockErrorf) Return() *TesterMock {
 //Set uses given function f as a mock of Tester.Errorf method
 func (m *mTesterMockErrorf) Set(f func(p string, p1 ...interface{})) *TesterMock {
 	m.mock.ErrorfFunc = f
+	m.mockExpectations = nil
 	return m.mock
 }
 
@@ -212,6 +214,7 @@ func (m *mTesterMockFatal) Return() *TesterMock {
 //Set uses given function f as a mock of Tester.Fatal method
 func (m *mTesterMockFatal) Set(f func(p ...interface{})) *TesterMock {
 	m.mock.FatalFunc = f
+	m.mockExpectations = nil
 	return m.mock
 }
 
@@ -278,6 +281,7 @@ func (m *mTesterMockFatalf) Return() *TesterMock {
 //Set uses given function f as a mock of Tester.Fatalf method
 func (m *mTesterMockFatalf) Set(f func(p string, p1 ...interface{})) *TesterMock {
 	m.mock.FatalfFunc = f
+	m.mockExpectations = nil
 	return m.mock
 }
 


### PR DESCRIPTION
Even if `FormatFunc` is set by `Set` method,
`FormatFunc` is not called if `mockExpectations` is set by `Expect` before.

`tests` package is updated by `Make test`.