### PR TITLE
Fix mockExpectations undefined error when argument is nothing

### DIFF
--- a/cmd/minimock/minimock.go
+++ b/cmd/minimock/minimock.go
@@ -330,7 +330,7 @@ const template = `
 		//Set uses given function f as a mock of {{$interfaceName}}.{{$methodName}} method
 		func (m *m{{$structName}}{{$methodName}}) Set(f func({{params $method}}) ({{results $method}})) *{{$structName}}{
 			m.mock.{{$methodName}}Func = f
-			m.mockExpectations = nil
+			{{if not (eq (params $method).String "")}}m.mockExpectations = nil{{end}}
 			return m.mock
 		}
 


### PR DESCRIPTION
Fix the bug of #12 