### PR TITLE
Add a Calls() method for call arg history

### DIFF
--- a/template.go
+++ b/template.go
@@ -44,7 +44,7 @@ const (
 			}
 			{{ range $method := $.Interface.Methods }}
 				m.{{$method.Name}}Mock = m{{$mock}}{{$method.Name}}{mock: m}
-				m.{{$method.Name}}Mock.callArgs = []*{{$mock}}{{$method.Name}}Params{}
+				{{ if $method.HasParams }} m.{{$method.Name}}Mock.callArgs = []*{{$mock}}{{$method.Name}}Params{} {{ end }}
 			{{ end }}
 			return m
 		}

--- a/tests/formatter_mock.go
+++ b/tests/formatter_mock.go
@@ -27,7 +27,9 @@ func NewFormatterMock(t minimock.Tester) *FormatterMock {
 	if controller, ok := t.(minimock.MockController); ok {
 		controller.RegisterMocker(m)
 	}
+
 	m.FormatMock = mFormatterMockFormat{mock: m}
+	m.FormatMock.callArgs = []*FormatterMockFormatParams{}
 
 	return m
 }
@@ -36,6 +38,7 @@ type mFormatterMockFormat struct {
 	mock               *FormatterMock
 	defaultExpectation *FormatterMockFormatExpectation
 	expectations       []*FormatterMockFormatExpectation
+	callArgs           []*FormatterMockFormatParams
 }
 
 // FormatterMockFormatExpectation specifies expectation struct of the Formatter.Format
@@ -130,8 +133,12 @@ func (m *FormatterMock) Format(s1 string, p1 ...interface{}) (s2 string) {
 	mm_atomic.AddUint64(&m.beforeFormatCounter, 1)
 	defer mm_atomic.AddUint64(&m.afterFormatCounter, 1)
 
+	// Record call args
+	params := &FormatterMockFormatParams{s1, p1}
+	m.FormatMock.callArgs = append(m.FormatMock.callArgs, params)
+
 	for _, e := range m.FormatMock.expectations {
-		if minimock.Equal(*e.params, FormatterMockFormatParams{s1, p1}) {
+		if minimock.Equal(e.params, params) {
 			mm_atomic.AddUint64(&e.Counter, 1)
 			return e.results.s2
 		}
@@ -166,6 +173,12 @@ func (m *FormatterMock) FormatAfterCounter() uint64 {
 // FormatBeforeCounter returns a count of FormatterMock.Format invocations
 func (m *FormatterMock) FormatBeforeCounter() uint64 {
 	return mm_atomic.LoadUint64(&m.beforeFormatCounter)
+}
+
+// Calls returns a list of arguments used in each call to FormatterMock.Format.
+// The list is in the same order as the calls were made (i.e. recent calls have a higher index)
+func (m *mFormatterMockFormat) Calls() []*FormatterMockFormatParams {
+	return m.callArgs
 }
 
 // MinimockFormatDone returns true if the count of the Format invocations corresponds

--- a/tests/formatter_mock_test.go
+++ b/tests/formatter_mock_test.go
@@ -299,6 +299,32 @@ func TestFormatterMock_Calls(t *testing.T) {
 	assert.Equal(t, expected, formatterMock.FormatMock.Calls())
 }
 
+// Verifies that Calls() returns a new shallow copy of the params list each time
+func TestFormatterMock_CallsReturnsCopy(t *testing.T) {
+	tester := NewTesterMock(t)
+	defer tester.MinimockFinish()
+
+	expected := []*FormatterMockFormatParams{
+		{"a1", []interface{}{"a1"}},
+		{"b1", []interface{}{"b2"}},
+	}
+
+	formatterMock := NewFormatterMock(tester)
+	callHistory := [][]*FormatterMockFormatParams{}
+
+	for _, p := range expected {
+		formatterMock.FormatMock.Expect(p.s1, p.p1...).Return("")
+		formatterMock.Format(p.s1, p.p1...)
+		callHistory = append(callHistory, formatterMock.FormatMock.Calls())
+	}
+
+	assert.Equal(t, len(expected), len(callHistory))
+
+	for i, c := range callHistory {
+		assert.Equal(t, i+1, len(c))
+	}
+}
+
 type dummyFormatter struct {
 	Formatter
 }

--- a/tests/formatter_mock_test.go
+++ b/tests/formatter_mock_test.go
@@ -264,6 +264,41 @@ func TestFormatterMock_MinimockWait(t *testing.T) {
 	formatterMock.MinimockWait(time.Millisecond)
 }
 
+// Verifies that Calls() doesn't return nil if no calls were made
+func TestFormatterMock_CallsNotNil(t *testing.T) {
+	tester := NewTesterMock(t)
+	defer tester.MinimockFinish()
+
+	formatterMock := NewFormatterMock(tester)
+	calls := formatterMock.FormatMock.Calls()
+
+	assert.NotNil(t, calls)
+	assert.Empty(t, calls)
+}
+
+// Verifies that Calls() returns the correct call args in the expected order
+func TestFormatterMock_Calls(t *testing.T) {
+	tester := NewTesterMock(t)
+	defer tester.MinimockFinish()
+
+	// Arguments used for each mock call
+	expected := []*FormatterMockFormatParams{
+		{"a1", []interface{}{}},
+		{"b1", []interface{}{"b2"}},
+		{"c1", []interface{}{"c2", "c3"}},
+		{"d1", []interface{}{"d2", "d3", "d4"}},
+	}
+
+	formatterMock := NewFormatterMock(tester)
+
+	for _, p := range expected {
+		formatterMock.FormatMock.Expect(p.s1, p.p1...).Return("")
+		formatterMock.Format(p.s1, p.p1...)
+	}
+
+	assert.Equal(t, expected, formatterMock.FormatMock.Calls())
+}
+
 type dummyFormatter struct {
 	Formatter
 }


### PR DESCRIPTION
This adds a `Calls()` method to the method mock object which returns a list of arguments the method was called with.

- `Calls()` is guaranteed to never return nil (will return an empty list if no calls are made)
- Methods which accept no arguments do not track their call params nor is there a `Calls()` method generated