### PR TITLE
ci: run lint and test for pull requests on GitHub Actions

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -10,4 +10,4 @@ jobs:
         with:
           go-version: '1.21.5'
       - run: make lint
-      - run: make vet
+      - run: make test

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,0 +1,13 @@
+---
+name: test
+on: pull_request
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4.1.1
+      - uses: actions/setup-go@v5.0.0
+        with:
+          go-version: '1.21.5'
+      - run: make lint
+      - run: make vet

--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ install:
 	go install ./cmd/minimock
 
 ./bin/golangci-lint: ./bin
-	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b ./bin v1.51.1
+	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b ./bin v1.55.2
 
 ./bin/goreleaser: ./bin
 	go install -modfile tools/go.mod github.com/goreleaser/goreleaser


### PR DESCRIPTION
Close #80

- Set up a GitHub Actions Workflow to run lint and test
- Update golangci-lint to v1.55.2 to resolve the lint error

```console
$ make lint
./bin/golangci-lint run --enable=goimports --disable=unused --exclude=S1023,"Error return value" ./tests/...
../../../../../.local/share/aquaproj-aqua/pkgs/http/golang.org/dl/go1.21.5.darwin-arm64.tar.gz/go/src/net/http/internal/chunked.go:79:14: undefined: max (typecheck)
        cr.excess = max(cr.excess, 0)
```

## Test

I confirmed the workflow works well.

- https://github.com/suzuki-shunsuke/minimock/pull/1
- https://github.com/suzuki-shunsuke/minimock/actions/runs/7405668194/job/20148965632?pr=1