### PR TITLE
ci: set up a GitHub Actions workflow to release minimock

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,21 @@
+---
+name: Release
+on:
+  push:
+    tags: [v*]
+permissions:
+  contents: write # To create releases
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4.1.1
+      - uses: actions/setup-go@v5.0.0
+        with:
+          go-version: '1.21.5'
+      - uses: goreleaser/goreleaser-action@v5.0.0
+        with:
+          version: v1.23.0
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ github.token }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,7 +1,4 @@
 project_name: minimock
-before:
-  hooks:
-    - make all
 builds:
 - 
   main: ./cmd/minimock/


### PR DESCRIPTION
Close #81

The workflow is triggered when you push GitHub tags.

## Test

I confirmed the workflow works well.

- https://github.com/suzuki-shunsuke/minimock/releases/tag/v3.3.3-2
- https://github.com/suzuki-shunsuke/minimock/actions/runs/7405810937/job/20149329560