### PR TITLE
ci: restrict the job permission for security

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -4,6 +4,7 @@ on: pull_request
 jobs:
   test:
     runs-on: ubuntu-latest
+    permissions: {}
     steps:
       - uses: actions/checkout@v4.1.1
       - uses: actions/setup-go@v5.0.0


### PR DESCRIPTION
I forgot to set the permission in https://github.com/gojuno/minimock/pull/82 .
This workflow doesn't require any permissions.
The permission should be restricted to least privileges.

https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#defining-access-for-the-github_token-scopes-1

> You can use the following syntax to disable permissions for all of the available scopes:
> 
> ```
> permissions: {}
> ```