### PR TITLE
feat: add 'Optional' to all mocked methods: 0 or more calls is now allowed

### DIFF
--- a/template.go
+++ b/template.go
@@ -65,6 +65,7 @@ const (
 			{{ $m := (printf "mm%s" $method.Name) }}
 
 			type m{{$mock}}{{$method.Name}}{{(params)}} struct {
+				optional             bool
 				mock              *{{$mock}}{{(paramsRef)}}
 				defaultExpectation   *{{$mock}}{{$method.Name}}Expectation{{(paramsRef)}}
 				expectations []*{{$mock}}{{$method.Name}}Expectation{{(paramsRef)}}
@@ -91,6 +92,16 @@ const (
 				// {{$mock}}{{$method.Name}}Results contains results of the {{$.Interface.Name}}.{{$method.Name}}
 				type {{$mock}}{{$method.Name}}Results{{(params)}} {{$method.ResultsStruct}}
 			{{end}}
+
+			// Marks this method to be optional. The default behavior of any method with Return() is '1 or more', meaning
+			// the test will fail minimock's automatic final call check if the mocked method was not called at least once.
+			// Optional() makes method check to work in '0 or more' mode.
+			// It is NOT RECOMMENDED to use this option by default unless you really need it, as it helps to
+			// catch the problems when the expected method call is totally skipped during test run.
+			func ({{$m}} *m{{$mock}}{{$method.Name}}{{(paramsRef)}}) Optional() *m{{$mock}}{{$method.Name}}{{(paramsRef)}} {
+				{{$m}}.optional = true
+				return {{$m}}
+			}
 
 			// Expect sets up expected params for {{$.Interface.Name}}.{{$method.Name}}
 			func ({{$m}} *m{{$mock}}{{$method.Name}}{{(paramsRef)}}) Expect({{$method.Params}}) *m{{$mock}}{{$method.Name}}{{(paramsRef)}} {
@@ -253,6 +264,11 @@ const (
 			// Minimock{{$method.Name}}Done returns true if the count of the {{$method.Name}} invocations corresponds
 			// the number of defined expectations
 			func (m *{{$mock}}{{(paramsRef)}}) Minimock{{$method.Name}}Done() bool {
+				if m.{{$method.Name}}Mock.optional {
+					// Optional methods provide '0 or more' call count restriction.
+					return true
+				}
+
 				for _, e := range m.{{$method.Name}}Mock.expectations {
 					if mm_atomic.LoadUint64(&e.Counter) < 1 {
 						return false


### PR DESCRIPTION
In some (quite rare, but anyway) test cases you cannot predict if the method will be called for particular instance of mocked interface.
Say, you test the concurrency and plan to execute 100 tasks. You expect the test to have 50 of tasks to be done and 50 to be not even started. But you do not know which of tasks the executor will choose, to set that 'the mock here should be called' and 'the mock here should NOT be called'. This is just out of your control, but you still want to check the constraint, that there is 50/50 results division.

For that case, the restriction of '1 or more' on a mocked method makes impossible to implement such test using minimock-generated interface mock implementation.

The default behavior of minimock to require calls for mocked methods is OK, it is just good to have control over it.