### PR TITLE
chore: remove the Make task "release"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,9 +43,6 @@ install:
 test:
 	go test -race ./... -v
 
-release: ./bin/goreleaser
-	./bin/goreleaser release --rm-dist
-
 build: ./bin/goreleaser
 	./bin/goreleaser build --snapshot --rm-dist
 


### PR DESCRIPTION
This task is unnecessary anymore as we release by CI.

- https://github.com/gojuno/minimock/pull/83

We should remove this task to prevent us from releasing on localhost accidentally.

- https://github.com/gojuno/minimock/issues/104#issuecomment-2138589276