### PR TITLE
[template] add when/then for functions without results

### DIFF
--- a/internal/templates/body.tmpl
+++ b/internal/templates/body.tmpl
@@ -202,8 +202,7 @@ func New{{$mock}}{{(params)}}(t minimock.Tester) *{{$mock}}{{(paramsRef)}} {
             return expectation
         }
 
-        // Then sets up {{$.Interface.Name}}.{{$method.Name}} return parameters for the expectation previously defined by the When method
-        {{if $method.HasResults }}
+        // Then sets up {{$.Interface.Name}}.{{$method.Name}} return parameters for the expectation previously defined by the When method{{if $method.HasResults }}
         func (e *{{$mock}}{{$method.Name}}Expectation{{(paramsRef)}}) Then({{$method.Results}}) *{{$mock}}{{(paramsRef)}} {
             e.results = &{{$mock}}{{$method.Name}}Results{{(paramsRef)}}{ {{ $method.ResultsNames }} }
             return e.mock

--- a/internal/templates/body.tmpl
+++ b/internal/templates/body.tmpl
@@ -202,15 +202,14 @@ func New{{$mock}}{{(params)}}(t minimock.Tester) *{{$mock}}{{(paramsRef)}} {
             return expectation
         }
 
-        {{if $method.HasResults }}
         // Then sets up {{$.Interface.Name}}.{{$method.Name}} return parameters for the expectation previously defined by the When method
+        {{if $method.HasResults }}
         func (e *{{$mock}}{{$method.Name}}Expectation{{(paramsRef)}}) Then({{$method.Results}}) *{{$mock}}{{(paramsRef)}} {
             e.results = &{{$mock}}{{$method.Name}}Results{{(paramsRef)}}{ {{ $method.ResultsNames }} }
             return e.mock
         }
         {{end}}
         {{if not $method.HasResults }}
-        // Then sets up {{$.Interface.Name}}.{{$method.Name}} return parameters for the expectation previously defined by the When method
         func (e *{{$mock}}{{$method.Name}}Expectation{{(paramsRef)}}) Then() *{{$mock}}{{(paramsRef)}} {
             return e.mock
         }

--- a/internal/templates/body.tmpl
+++ b/internal/templates/body.tmpl
@@ -185,7 +185,7 @@ func New{{$mock}}{{(params)}}(t minimock.Tester) *{{$mock}}{{(paramsRef)}} {
         return {{$m}}.mock
     }
 
-    {{if (and $method.HasParams $method.HasResults)}}
+    {{if $method.HasParams }}
         // When sets expectation for the {{$.Interface.Name}}.{{$method.Name}} which will trigger the result defined by the following
         // Then helper
         func ({{$m}} *m{{$mock}}{{$method.Name}}{{(paramsRef)}}) When({{$method.Params}}) *{{$mock}}{{$method.Name}}Expectation{{(paramsRef)}} {
@@ -202,11 +202,19 @@ func New{{$mock}}{{(params)}}(t minimock.Tester) *{{$mock}}{{(paramsRef)}} {
             return expectation
         }
 
+        {{if $method.HasResults }}
         // Then sets up {{$.Interface.Name}}.{{$method.Name}} return parameters for the expectation previously defined by the When method
         func (e *{{$mock}}{{$method.Name}}Expectation{{(paramsRef)}}) Then({{$method.Results}}) *{{$mock}}{{(paramsRef)}} {
             e.results = &{{$mock}}{{$method.Name}}Results{{(paramsRef)}}{ {{ $method.ResultsNames }} }
             return e.mock
         }
+        {{end}}
+        {{if not $method.HasResults }}
+        // Then sets up {{$.Interface.Name}}.{{$method.Name}} return parameters for the expectation previously defined by the When method
+        func (e *{{$mock}}{{$method.Name}}Expectation{{(paramsRef)}}) Then() *{{$mock}}{{(paramsRef)}} {
+            return e.mock
+        }
+        {{end}}
     {{end}}
 
     // Times sets number of times {{$.Interface.Name}}.{{$method.Name}} should be invoked

--- a/tests/context_accepter_mock.go
+++ b/tests/context_accepter_mock.go
@@ -200,6 +200,28 @@ func (mmAcceptContext *mContextAccepterMockAcceptContext) Set(f func(ctx context
 	return mmAcceptContext.mock
 }
 
+// When sets expectation for the contextAccepter.AcceptContext which will trigger the result defined by the following
+// Then helper
+func (mmAcceptContext *mContextAccepterMockAcceptContext) When(ctx context.Context) *ContextAccepterMockAcceptContextExpectation {
+	if mmAcceptContext.mock.funcAcceptContext != nil {
+		mmAcceptContext.mock.t.Fatalf("ContextAccepterMock.AcceptContext mock is already set by Set")
+	}
+
+	expectation := &ContextAccepterMockAcceptContextExpectation{
+		mock:               mmAcceptContext.mock,
+		params:             &ContextAccepterMockAcceptContextParams{ctx},
+		expectationOrigins: ContextAccepterMockAcceptContextExpectationOrigins{origin: minimock.CallerInfo(1)},
+	}
+	mmAcceptContext.expectations = append(mmAcceptContext.expectations, expectation)
+	return expectation
+}
+
+// Then sets up contextAccepter.AcceptContext return parameters for the expectation previously defined by the When method
+
+func (e *ContextAccepterMockAcceptContextExpectation) Then() *ContextAccepterMock {
+	return e.mock
+}
+
 // Times sets number of times contextAccepter.AcceptContext should be invoked
 func (mmAcceptContext *mContextAccepterMockAcceptContext) Times(n uint64) *mContextAccepterMockAcceptContext {
 	if n == 0 {

--- a/tests/context_accepter_mock_test.go
+++ b/tests/context_accepter_mock_test.go
@@ -48,6 +48,16 @@ func TestContextAccepterMock_WhenThenMatchAnycontext(t *testing.T) {
 	assert.Equal(t, 42, result)
 }
 
+func TestContextAccepterMock_WhenThenMatchAnycontextWithoutArgs(t *testing.T) {
+	tester := NewTesterMock(t)
+	tester.CleanupMock.Return().HelperMock.Return()
+
+	mock := NewContextAccepterMock(tester).
+		AcceptContextMock.When(minimock.AnyContext).Then()
+
+	mock.AcceptContext(context.TODO())
+}
+
 func TestContextAccepterMock_DiffWithoutAnyContext(t *testing.T) {
 	tester := NewTesterMock(t)
 	tester.CleanupMock.Return().HelperMock.Return()

--- a/tests/generic_complex_union.go
+++ b/tests/generic_complex_union.go
@@ -179,6 +179,28 @@ func (mmName *mGenericComplexUnionMockName[T]) Set(f func(t1 T)) *GenericComplex
 	return mmName.mock
 }
 
+// When sets expectation for the genericComplexUnion.Name which will trigger the result defined by the following
+// Then helper
+func (mmName *mGenericComplexUnionMockName[T]) When(t1 T) *GenericComplexUnionMockNameExpectation[T] {
+	if mmName.mock.funcName != nil {
+		mmName.mock.t.Fatalf("GenericComplexUnionMock.Name mock is already set by Set")
+	}
+
+	expectation := &GenericComplexUnionMockNameExpectation[T]{
+		mock:               mmName.mock,
+		params:             &GenericComplexUnionMockNameParams[T]{t1},
+		expectationOrigins: GenericComplexUnionMockNameExpectationOrigins{origin: minimock.CallerInfo(1)},
+	}
+	mmName.expectations = append(mmName.expectations, expectation)
+	return expectation
+}
+
+// Then sets up genericComplexUnion.Name return parameters for the expectation previously defined by the When method
+
+func (e *GenericComplexUnionMockNameExpectation[T]) Then() *GenericComplexUnionMock[T] {
+	return e.mock
+}
+
 // Times sets number of times genericComplexUnion.Name should be invoked
 func (mmName *mGenericComplexUnionMockName[T]) Times(n uint64) *mGenericComplexUnionMockName[T] {
 	if n == 0 {

--- a/tests/generic_in.go
+++ b/tests/generic_in.go
@@ -179,6 +179,28 @@ func (mmName *mGenericInMockName[T]) Set(f func(t1 T)) *GenericInMock[T] {
 	return mmName.mock
 }
 
+// When sets expectation for the genericIn.Name which will trigger the result defined by the following
+// Then helper
+func (mmName *mGenericInMockName[T]) When(t1 T) *GenericInMockNameExpectation[T] {
+	if mmName.mock.funcName != nil {
+		mmName.mock.t.Fatalf("GenericInMock.Name mock is already set by Set")
+	}
+
+	expectation := &GenericInMockNameExpectation[T]{
+		mock:               mmName.mock,
+		params:             &GenericInMockNameParams[T]{t1},
+		expectationOrigins: GenericInMockNameExpectationOrigins{origin: minimock.CallerInfo(1)},
+	}
+	mmName.expectations = append(mmName.expectations, expectation)
+	return expectation
+}
+
+// Then sets up genericIn.Name return parameters for the expectation previously defined by the When method
+
+func (e *GenericInMockNameExpectation[T]) Then() *GenericInMock[T] {
+	return e.mock
+}
+
 // Times sets number of times genericIn.Name should be invoked
 func (mmName *mGenericInMockName[T]) Times(n uint64) *mGenericInMockName[T] {
 	if n == 0 {

--- a/tests/generic_inline_union.go
+++ b/tests/generic_inline_union.go
@@ -179,6 +179,28 @@ func (mmName *mGenericInlineUnionMockName[T]) Set(f func(t1 T)) *GenericInlineUn
 	return mmName.mock
 }
 
+// When sets expectation for the genericInlineUnion.Name which will trigger the result defined by the following
+// Then helper
+func (mmName *mGenericInlineUnionMockName[T]) When(t1 T) *GenericInlineUnionMockNameExpectation[T] {
+	if mmName.mock.funcName != nil {
+		mmName.mock.t.Fatalf("GenericInlineUnionMock.Name mock is already set by Set")
+	}
+
+	expectation := &GenericInlineUnionMockNameExpectation[T]{
+		mock:               mmName.mock,
+		params:             &GenericInlineUnionMockNameParams[T]{t1},
+		expectationOrigins: GenericInlineUnionMockNameExpectationOrigins{origin: minimock.CallerInfo(1)},
+	}
+	mmName.expectations = append(mmName.expectations, expectation)
+	return expectation
+}
+
+// Then sets up genericInlineUnion.Name return parameters for the expectation previously defined by the When method
+
+func (e *GenericInlineUnionMockNameExpectation[T]) Then() *GenericInlineUnionMock[T] {
+	return e.mock
+}
+
 // Times sets number of times genericInlineUnion.Name should be invoked
 func (mmName *mGenericInlineUnionMockName[T]) Times(n uint64) *mGenericInlineUnionMockName[T] {
 	if n == 0 {

--- a/tests/generic_inline_with_many_options.go
+++ b/tests/generic_inline_with_many_options.go
@@ -179,6 +179,28 @@ func (mmName *mGenericInlineUnionWithManyTypesMockName[T]) Set(f func(t1 T)) *Ge
 	return mmName.mock
 }
 
+// When sets expectation for the genericInlineUnionWithManyTypes.Name which will trigger the result defined by the following
+// Then helper
+func (mmName *mGenericInlineUnionWithManyTypesMockName[T]) When(t1 T) *GenericInlineUnionWithManyTypesMockNameExpectation[T] {
+	if mmName.mock.funcName != nil {
+		mmName.mock.t.Fatalf("GenericInlineUnionWithManyTypesMock.Name mock is already set by Set")
+	}
+
+	expectation := &GenericInlineUnionWithManyTypesMockNameExpectation[T]{
+		mock:               mmName.mock,
+		params:             &GenericInlineUnionWithManyTypesMockNameParams[T]{t1},
+		expectationOrigins: GenericInlineUnionWithManyTypesMockNameExpectationOrigins{origin: minimock.CallerInfo(1)},
+	}
+	mmName.expectations = append(mmName.expectations, expectation)
+	return expectation
+}
+
+// Then sets up genericInlineUnionWithManyTypes.Name return parameters for the expectation previously defined by the When method
+
+func (e *GenericInlineUnionWithManyTypesMockNameExpectation[T]) Then() *GenericInlineUnionWithManyTypesMock[T] {
+	return e.mock
+}
+
 // Times sets number of times genericInlineUnionWithManyTypes.Name should be invoked
 func (mmName *mGenericInlineUnionWithManyTypesMockName[T]) Times(n uint64) *mGenericInlineUnionWithManyTypesMockName[T] {
 	if n == 0 {

--- a/tests/generic_multiple_args_with_different_types.go
+++ b/tests/generic_multiple_args_with_different_types.go
@@ -206,6 +206,28 @@ func (mmName *mGenericMultipleTypesMockName[T, K]) Set(f func(t1 T, k1 K)) *Gene
 	return mmName.mock
 }
 
+// When sets expectation for the genericMultipleTypes.Name which will trigger the result defined by the following
+// Then helper
+func (mmName *mGenericMultipleTypesMockName[T, K]) When(t1 T, k1 K) *GenericMultipleTypesMockNameExpectation[T, K] {
+	if mmName.mock.funcName != nil {
+		mmName.mock.t.Fatalf("GenericMultipleTypesMock.Name mock is already set by Set")
+	}
+
+	expectation := &GenericMultipleTypesMockNameExpectation[T, K]{
+		mock:               mmName.mock,
+		params:             &GenericMultipleTypesMockNameParams[T, K]{t1, k1},
+		expectationOrigins: GenericMultipleTypesMockNameExpectationOrigins{origin: minimock.CallerInfo(1)},
+	}
+	mmName.expectations = append(mmName.expectations, expectation)
+	return expectation
+}
+
+// Then sets up genericMultipleTypes.Name return parameters for the expectation previously defined by the When method
+
+func (e *GenericMultipleTypesMockNameExpectation[T, K]) Then() *GenericMultipleTypesMock[T, K] {
+	return e.mock
+}
+
 // Times sets number of times genericMultipleTypes.Name should be invoked
 func (mmName *mGenericMultipleTypesMockName[T, K]) Times(n uint64) *mGenericMultipleTypesMockName[T, K] {
 	if n == 0 {

--- a/tests/generic_simple_union.go
+++ b/tests/generic_simple_union.go
@@ -179,6 +179,28 @@ func (mmName *mGenericSimpleUnionMockName[T]) Set(f func(t1 T)) *GenericSimpleUn
 	return mmName.mock
 }
 
+// When sets expectation for the genericSimpleUnion.Name which will trigger the result defined by the following
+// Then helper
+func (mmName *mGenericSimpleUnionMockName[T]) When(t1 T) *GenericSimpleUnionMockNameExpectation[T] {
+	if mmName.mock.funcName != nil {
+		mmName.mock.t.Fatalf("GenericSimpleUnionMock.Name mock is already set by Set")
+	}
+
+	expectation := &GenericSimpleUnionMockNameExpectation[T]{
+		mock:               mmName.mock,
+		params:             &GenericSimpleUnionMockNameParams[T]{t1},
+		expectationOrigins: GenericSimpleUnionMockNameExpectationOrigins{origin: minimock.CallerInfo(1)},
+	}
+	mmName.expectations = append(mmName.expectations, expectation)
+	return expectation
+}
+
+// Then sets up genericSimpleUnion.Name return parameters for the expectation previously defined by the When method
+
+func (e *GenericSimpleUnionMockNameExpectation[T]) Then() *GenericSimpleUnionMock[T] {
+	return e.mock
+}
+
 // Times sets number of times genericSimpleUnion.Name should be invoked
 func (mmName *mGenericSimpleUnionMockName[T]) Times(n uint64) *mGenericSimpleUnionMockName[T] {
 	if n == 0 {

--- a/tests/generic_specific.go
+++ b/tests/generic_specific.go
@@ -180,6 +180,28 @@ func (mmName *mGenericSpecificMockName[T]) Set(f func(t1 T)) *GenericSpecificMoc
 	return mmName.mock
 }
 
+// When sets expectation for the genericSpecific.Name which will trigger the result defined by the following
+// Then helper
+func (mmName *mGenericSpecificMockName[T]) When(t1 T) *GenericSpecificMockNameExpectation[T] {
+	if mmName.mock.funcName != nil {
+		mmName.mock.t.Fatalf("GenericSpecificMock.Name mock is already set by Set")
+	}
+
+	expectation := &GenericSpecificMockNameExpectation[T]{
+		mock:               mmName.mock,
+		params:             &GenericSpecificMockNameParams[T]{t1},
+		expectationOrigins: GenericSpecificMockNameExpectationOrigins{origin: minimock.CallerInfo(1)},
+	}
+	mmName.expectations = append(mmName.expectations, expectation)
+	return expectation
+}
+
+// Then sets up genericSpecific.Name return parameters for the expectation previously defined by the When method
+
+func (e *GenericSpecificMockNameExpectation[T]) Then() *GenericSpecificMock[T] {
+	return e.mock
+}
+
 // Times sets number of times genericSpecific.Name should be invoked
 func (mmName *mGenericSpecificMockName[T]) Times(n uint64) *mGenericSpecificMockName[T] {
 	if n == 0 {

--- a/tests/package_name_specified_test.go
+++ b/tests/package_name_specified_test.go
@@ -237,6 +237,28 @@ func (mmCleanup *mTesterMockCleanup) Set(f func(f func())) *TesterMock {
 	return mmCleanup.mock
 }
 
+// When sets expectation for the Tester.Cleanup which will trigger the result defined by the following
+// Then helper
+func (mmCleanup *mTesterMockCleanup) When(f func()) *TesterMockCleanupExpectation {
+	if mmCleanup.mock.funcCleanup != nil {
+		mmCleanup.mock.t.Fatalf("TesterMock.Cleanup mock is already set by Set")
+	}
+
+	expectation := &TesterMockCleanupExpectation{
+		mock:               mmCleanup.mock,
+		params:             &TesterMockCleanupParams{f},
+		expectationOrigins: TesterMockCleanupExpectationOrigins{origin: minimock.CallerInfo(1)},
+	}
+	mmCleanup.expectations = append(mmCleanup.expectations, expectation)
+	return expectation
+}
+
+// Then sets up Tester.Cleanup return parameters for the expectation previously defined by the When method
+
+func (e *TesterMockCleanupExpectation) Then() *TesterMock {
+	return e.mock
+}
+
 // Times sets number of times Tester.Cleanup should be invoked
 func (mmCleanup *mTesterMockCleanup) Times(n uint64) *mTesterMockCleanup {
 	if n == 0 {
@@ -517,6 +539,28 @@ func (mmError *mTesterMockError) Set(f func(p1 ...interface{})) *TesterMock {
 	mmError.mock.funcError = f
 	mmError.mock.funcErrorOrigin = minimock.CallerInfo(1)
 	return mmError.mock
+}
+
+// When sets expectation for the Tester.Error which will trigger the result defined by the following
+// Then helper
+func (mmError *mTesterMockError) When(p1 ...interface{}) *TesterMockErrorExpectation {
+	if mmError.mock.funcError != nil {
+		mmError.mock.t.Fatalf("TesterMock.Error mock is already set by Set")
+	}
+
+	expectation := &TesterMockErrorExpectation{
+		mock:               mmError.mock,
+		params:             &TesterMockErrorParams{p1},
+		expectationOrigins: TesterMockErrorExpectationOrigins{origin: minimock.CallerInfo(1)},
+	}
+	mmError.expectations = append(mmError.expectations, expectation)
+	return expectation
+}
+
+// Then sets up Tester.Error return parameters for the expectation previously defined by the When method
+
+func (e *TesterMockErrorExpectation) Then() *TesterMock {
+	return e.mock
 }
 
 // Times sets number of times Tester.Error should be invoked
@@ -825,6 +869,28 @@ func (mmErrorf *mTesterMockErrorf) Set(f func(format string, args ...interface{}
 	mmErrorf.mock.funcErrorf = f
 	mmErrorf.mock.funcErrorfOrigin = minimock.CallerInfo(1)
 	return mmErrorf.mock
+}
+
+// When sets expectation for the Tester.Errorf which will trigger the result defined by the following
+// Then helper
+func (mmErrorf *mTesterMockErrorf) When(format string, args ...interface{}) *TesterMockErrorfExpectation {
+	if mmErrorf.mock.funcErrorf != nil {
+		mmErrorf.mock.t.Fatalf("TesterMock.Errorf mock is already set by Set")
+	}
+
+	expectation := &TesterMockErrorfExpectation{
+		mock:               mmErrorf.mock,
+		params:             &TesterMockErrorfParams{format, args},
+		expectationOrigins: TesterMockErrorfExpectationOrigins{origin: minimock.CallerInfo(1)},
+	}
+	mmErrorf.expectations = append(mmErrorf.expectations, expectation)
+	return expectation
+}
+
+// Then sets up Tester.Errorf return parameters for the expectation previously defined by the When method
+
+func (e *TesterMockErrorfExpectation) Then() *TesterMock {
+	return e.mock
 }
 
 // Times sets number of times Tester.Errorf should be invoked
@@ -1292,6 +1358,28 @@ func (mmFatal *mTesterMockFatal) Set(f func(args ...interface{})) *TesterMock {
 	return mmFatal.mock
 }
 
+// When sets expectation for the Tester.Fatal which will trigger the result defined by the following
+// Then helper
+func (mmFatal *mTesterMockFatal) When(args ...interface{}) *TesterMockFatalExpectation {
+	if mmFatal.mock.funcFatal != nil {
+		mmFatal.mock.t.Fatalf("TesterMock.Fatal mock is already set by Set")
+	}
+
+	expectation := &TesterMockFatalExpectation{
+		mock:               mmFatal.mock,
+		params:             &TesterMockFatalParams{args},
+		expectationOrigins: TesterMockFatalExpectationOrigins{origin: minimock.CallerInfo(1)},
+	}
+	mmFatal.expectations = append(mmFatal.expectations, expectation)
+	return expectation
+}
+
+// Then sets up Tester.Fatal return parameters for the expectation previously defined by the When method
+
+func (e *TesterMockFatalExpectation) Then() *TesterMock {
+	return e.mock
+}
+
 // Times sets number of times Tester.Fatal should be invoked
 func (mmFatal *mTesterMockFatal) Times(n uint64) *mTesterMockFatal {
 	if n == 0 {
@@ -1598,6 +1686,28 @@ func (mmFatalf *mTesterMockFatalf) Set(f func(format string, args ...interface{}
 	mmFatalf.mock.funcFatalf = f
 	mmFatalf.mock.funcFatalfOrigin = minimock.CallerInfo(1)
 	return mmFatalf.mock
+}
+
+// When sets expectation for the Tester.Fatalf which will trigger the result defined by the following
+// Then helper
+func (mmFatalf *mTesterMockFatalf) When(format string, args ...interface{}) *TesterMockFatalfExpectation {
+	if mmFatalf.mock.funcFatalf != nil {
+		mmFatalf.mock.t.Fatalf("TesterMock.Fatalf mock is already set by Set")
+	}
+
+	expectation := &TesterMockFatalfExpectation{
+		mock:               mmFatalf.mock,
+		params:             &TesterMockFatalfParams{format, args},
+		expectationOrigins: TesterMockFatalfExpectationOrigins{origin: minimock.CallerInfo(1)},
+	}
+	mmFatalf.expectations = append(mmFatalf.expectations, expectation)
+	return expectation
+}
+
+// Then sets up Tester.Fatalf return parameters for the expectation previously defined by the When method
+
+func (e *TesterMockFatalfExpectation) Then() *TesterMock {
+	return e.mock
 }
 
 // Times sets number of times Tester.Fatalf should be invoked

--- a/tests/tester_mock_test.go
+++ b/tests/tester_mock_test.go
@@ -237,6 +237,28 @@ func (mmCleanup *mTesterMockCleanup) Set(f func(f func())) *TesterMock {
 	return mmCleanup.mock
 }
 
+// When sets expectation for the Tester.Cleanup which will trigger the result defined by the following
+// Then helper
+func (mmCleanup *mTesterMockCleanup) When(f func()) *TesterMockCleanupExpectation {
+	if mmCleanup.mock.funcCleanup != nil {
+		mmCleanup.mock.t.Fatalf("TesterMock.Cleanup mock is already set by Set")
+	}
+
+	expectation := &TesterMockCleanupExpectation{
+		mock:               mmCleanup.mock,
+		params:             &TesterMockCleanupParams{f},
+		expectationOrigins: TesterMockCleanupExpectationOrigins{origin: minimock.CallerInfo(1)},
+	}
+	mmCleanup.expectations = append(mmCleanup.expectations, expectation)
+	return expectation
+}
+
+// Then sets up Tester.Cleanup return parameters for the expectation previously defined by the When method
+
+func (e *TesterMockCleanupExpectation) Then() *TesterMock {
+	return e.mock
+}
+
 // Times sets number of times Tester.Cleanup should be invoked
 func (mmCleanup *mTesterMockCleanup) Times(n uint64) *mTesterMockCleanup {
 	if n == 0 {
@@ -517,6 +539,28 @@ func (mmError *mTesterMockError) Set(f func(p1 ...interface{})) *TesterMock {
 	mmError.mock.funcError = f
 	mmError.mock.funcErrorOrigin = minimock.CallerInfo(1)
 	return mmError.mock
+}
+
+// When sets expectation for the Tester.Error which will trigger the result defined by the following
+// Then helper
+func (mmError *mTesterMockError) When(p1 ...interface{}) *TesterMockErrorExpectation {
+	if mmError.mock.funcError != nil {
+		mmError.mock.t.Fatalf("TesterMock.Error mock is already set by Set")
+	}
+
+	expectation := &TesterMockErrorExpectation{
+		mock:               mmError.mock,
+		params:             &TesterMockErrorParams{p1},
+		expectationOrigins: TesterMockErrorExpectationOrigins{origin: minimock.CallerInfo(1)},
+	}
+	mmError.expectations = append(mmError.expectations, expectation)
+	return expectation
+}
+
+// Then sets up Tester.Error return parameters for the expectation previously defined by the When method
+
+func (e *TesterMockErrorExpectation) Then() *TesterMock {
+	return e.mock
 }
 
 // Times sets number of times Tester.Error should be invoked
@@ -825,6 +869,28 @@ func (mmErrorf *mTesterMockErrorf) Set(f func(format string, args ...interface{}
 	mmErrorf.mock.funcErrorf = f
 	mmErrorf.mock.funcErrorfOrigin = minimock.CallerInfo(1)
 	return mmErrorf.mock
+}
+
+// When sets expectation for the Tester.Errorf which will trigger the result defined by the following
+// Then helper
+func (mmErrorf *mTesterMockErrorf) When(format string, args ...interface{}) *TesterMockErrorfExpectation {
+	if mmErrorf.mock.funcErrorf != nil {
+		mmErrorf.mock.t.Fatalf("TesterMock.Errorf mock is already set by Set")
+	}
+
+	expectation := &TesterMockErrorfExpectation{
+		mock:               mmErrorf.mock,
+		params:             &TesterMockErrorfParams{format, args},
+		expectationOrigins: TesterMockErrorfExpectationOrigins{origin: minimock.CallerInfo(1)},
+	}
+	mmErrorf.expectations = append(mmErrorf.expectations, expectation)
+	return expectation
+}
+
+// Then sets up Tester.Errorf return parameters for the expectation previously defined by the When method
+
+func (e *TesterMockErrorfExpectation) Then() *TesterMock {
+	return e.mock
 }
 
 // Times sets number of times Tester.Errorf should be invoked
@@ -1292,6 +1358,28 @@ func (mmFatal *mTesterMockFatal) Set(f func(args ...interface{})) *TesterMock {
 	return mmFatal.mock
 }
 
+// When sets expectation for the Tester.Fatal which will trigger the result defined by the following
+// Then helper
+func (mmFatal *mTesterMockFatal) When(args ...interface{}) *TesterMockFatalExpectation {
+	if mmFatal.mock.funcFatal != nil {
+		mmFatal.mock.t.Fatalf("TesterMock.Fatal mock is already set by Set")
+	}
+
+	expectation := &TesterMockFatalExpectation{
+		mock:               mmFatal.mock,
+		params:             &TesterMockFatalParams{args},
+		expectationOrigins: TesterMockFatalExpectationOrigins{origin: minimock.CallerInfo(1)},
+	}
+	mmFatal.expectations = append(mmFatal.expectations, expectation)
+	return expectation
+}
+
+// Then sets up Tester.Fatal return parameters for the expectation previously defined by the When method
+
+func (e *TesterMockFatalExpectation) Then() *TesterMock {
+	return e.mock
+}
+
 // Times sets number of times Tester.Fatal should be invoked
 func (mmFatal *mTesterMockFatal) Times(n uint64) *mTesterMockFatal {
 	if n == 0 {
@@ -1598,6 +1686,28 @@ func (mmFatalf *mTesterMockFatalf) Set(f func(format string, args ...interface{}
 	mmFatalf.mock.funcFatalf = f
 	mmFatalf.mock.funcFatalfOrigin = minimock.CallerInfo(1)
 	return mmFatalf.mock
+}
+
+// When sets expectation for the Tester.Fatalf which will trigger the result defined by the following
+// Then helper
+func (mmFatalf *mTesterMockFatalf) When(format string, args ...interface{}) *TesterMockFatalfExpectation {
+	if mmFatalf.mock.funcFatalf != nil {
+		mmFatalf.mock.t.Fatalf("TesterMock.Fatalf mock is already set by Set")
+	}
+
+	expectation := &TesterMockFatalfExpectation{
+		mock:               mmFatalf.mock,
+		params:             &TesterMockFatalfParams{format, args},
+		expectationOrigins: TesterMockFatalfExpectationOrigins{origin: minimock.CallerInfo(1)},
+	}
+	mmFatalf.expectations = append(mmFatalf.expectations, expectation)
+	return expectation
+}
+
+// Then sets up Tester.Fatalf return parameters for the expectation previously defined by the When method
+
+func (e *TesterMockFatalfExpectation) Then() *TesterMock {
+	return e.mock
 }
 
 // Times sets number of times Tester.Fatalf should be invoked


### PR DESCRIPTION
## Description
When i use minimock, i want to use When/Then functional for functions without result.
It helps me with checking strict different inputs.

## Changes
### Before:
We generate When/Then functions only for functions with result

### After:
We generate When/Then functions for every functions with or without result

## Example
Used struct from minimock repo. 

### User flow:
```go
ContextAccepter.AcceptContext.When(context.TODO()).Then()
ContextAccepter.AcceptContext.When(context.Background()).Then()
```

### Generated:
```go
// generated same as for functions with result
func (mmAcceptContext *mContextAccepterMockAcceptContext) When(ctx context.Context) *ContextAccepterMockAcceptContextExpectation {
	if mmAcceptContext.mock.funcAcceptContext != nil {
		mmAcceptContext.mock.t.Fatalf("ContextAccepterMock.AcceptContext mock is already set by Set")
	}

	expectation := &ContextAccepterMockAcceptContextExpectation{
		mock:               mmAcceptContext.mock,
		params:             &ContextAccepterMockAcceptContextParams{ctx},
		expectationOrigins: ContextAccepterMockAcceptContextExpectationOrigins{origin: minimock.CallerInfo(1)},
	}
	mmAcceptContext.expectations = append(mmAcceptContext.expectations, expectation)
	return expectation
}

// here's removed input parameters
// this function used to save fluent-style 
func (e *ContextAccepterMockAcceptContextExpectation) Then() *ContextAccepterMock {
        // here's removed working with result
	return e.mock
}
```