### PR TITLE
Fix typo in when/then example

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ formatterMock.FormatMock.When("Hi %s!", "there").Then("Hi there!")
 alternatively you can use the one-liner:
 
 ```go
-formatterMock = NewFormatterMock(mc).When("Hello %s!", "world").Then("Hello world!").When("Hi %s!", "there").Then("Hi there!")
+formatterMock = NewFormatterMock(mc).FormatMock.When("Hello %s!", "world").Then("Hello world!").FormatMock.When("Hi %s!", "there").Then("Hi there!")
 ```
 
 ### Setting up a mock using the Set method:


### PR DESCRIPTION
In README.md, the one-liner...
```go
formatterMock = NewFormatterMock(mc).When("Hello %s!", "world").Then("Hello world!").When("Hi %s!", "there").Then("Hi there!")
```
...Is not valid, because `When` is only applied on a `*Mock` fields, and also `Then` returns the original mock, not the one describing the method.

So the correct example would be:
```go
formatterMock = NewFormatterMock(mc).FormatMock.When("Hello %s!", "world").Then("Hello world!").FormatMock.When("Hi %s!", "there").Then("Hi there!")
```