### PR TITLE
Throw error when no interfaces are provided

### DIFF
--- a/cmd/minimock/minimock.go
+++ b/cmd/minimock/minimock.go
@@ -150,6 +150,10 @@ func run(opts *options) (err error) {
 
 		interfaces := types.FindAllInterfaces(astPackage, in.Type)
 
+		if len(interfaces) == 0 {
+			return errors.Errorf("no interfaces were provided")
+		}
+
 		packageName := ""
 		if len(opts.interfaces) == len(opts.packageNames) {
 			packageName = opts.packageNames[i]


### PR DESCRIPTION
Hello! I've tried minimock recently, and it's a great tool. However, when I tried it, I got stuck for a while because I accidentally specified a struct implementing an interface instead of the interface itself.

Consider the following source code:

```
package main

type Formatter interface {
	Format(string, ...interface{}) string
}

type FormatterImpl struct {
}

func (i *FormatterImpl) Format(string, ...interface{}) string {
	return ""
}
```

If instead of `minimock -i Formatter` you run `minimock -i FormatterImpl`, no output is generated, which is expected. However, there is no error - it just exits silently. Since specifying a struct instead of interface is always wrong, I propose throwing an error in this case - it's a small patch, but it might save some of the user's time.